### PR TITLE
Replace is not with !=

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -46,7 +46,7 @@ def get_messages_from_json_event(event) -> list[dict]:
     messages = [json.loads(sqs_record["body"]) for sqs_record in sqs_records]
     non_deleted_messages = [message
                             for message in messages
-                            if message["status"] is not "Deleted" and message["tableItemIdentifier"] is not ""]
+                            if message["status"] != "Deleted" and message["tableItemIdentifier"] != ""]
     return non_deleted_messages
 
 

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -46,7 +46,7 @@ def get_messages_from_json_event(event) -> list[dict]:
     messages = [json.loads(sqs_record["body"]) for sqs_record in sqs_records]
     non_deleted_messages = [message
                             for message in messages
-                            if message["status"] != "Deleted" and message["tableItemIdentifier"] != ""]
+                            if message["status"] != "Deleted"]
     return non_deleted_messages
 
 
@@ -60,5 +60,7 @@ def lambda_handler(event, context):
 
     for message_json_as_dict in message_jsons_as_dicts:
         primary_key_value = message_json_as_dict["tableItemIdentifier"]
+        if primary_key_value == "":
+            raise ValueError(f"Table identifier is missing for message {message_json_as_dict}")
         items_with_id = get_items_with_id(client, table_name, primary_key, primary_key_value)
         add_true_to_ingest_cc_attribute(client, table_name, primary_key, sort_key, items_with_id)

--- a/test/test_lambda_function.py
+++ b/test/test_lambda_function.py
@@ -59,7 +59,6 @@ class TestCcNotificationHandler(unittest.TestCase):
             messages_with_identifier,
             [
                 {"tableItemIdentifier": "identifier", "status": "Created"},
-                {"tableItemIdentifier": "identifier", "status": "Deleted"},
                 {"tableItemIdentifier": "differentIdentifier", "status": "Updated"}
             ]
         )

--- a/test/test_lambda_function.py
+++ b/test/test_lambda_function.py
@@ -50,7 +50,7 @@ class TestCcNotificationHandler(unittest.TestCase):
         )
 
     def test_get_messages_from_json_event_should_return_all_messages_except_those_that_have_an_empty_identifier_and_are_deleted(
-        self):
+            self):
         event = self.default_event
 
         messages_with_identifier = get_messages_from_json_event(event)
@@ -59,7 +59,7 @@ class TestCcNotificationHandler(unittest.TestCase):
             messages_with_identifier,
             [
                 {"tableItemIdentifier": "identifier", "status": "Created"},
-                {"tableItemIdentifier": "differentIdentifier", "status": "Updated"}
+                {"tableItemIdentifier": "differentIdentifier", "status": "Updated"},
             ]
         )
 
@@ -108,7 +108,7 @@ class TestCcNotificationHandler(unittest.TestCase):
         table.update_item.assert_not_called()
 
     def test_add_true_to_ingest_cc_attribute_should_add_ingest_cc_attr_with_true_value_if_current_value_is_not_true(
-        self):
+            self):
         self.create_table()
         identifier1 = {"id": {"S": "identifier1"}, "batchId": {"S": "batchIdValue"}, "ingested_CC": {"S": "false"}}
         identifier2 = {"id": {"S": "identifier2"}, "batchId": {"S": "batchIdValue"}, "ingested_CC": {"S": "tru"}}
@@ -142,6 +142,27 @@ class TestCcNotificationHandler(unittest.TestCase):
         new_ingested_cc_value = item_response["Item"]["ingested_CC"]
 
         self.assertEqual(new_ingested_cc_value, {"S": "true"})
+
+    def test_lambda_handler_should_raise_error_if_table_identifier_empty(self):
+        os.environ["DYNAMO_TABLE_NAME"] = self.table_name
+        self.create_table()
+        self.put_item_in_table({"id": {"S": "identifier"}, "batchId": {"S": "batchIdValue"}})
+
+        with self.assertRaises(ValueError) as context:
+            lambda_handler(self.empty_table_identifier_event, None)
+
+        expected_error = "Table identifier is missing for message {'tableItemIdentifier': '', 'status': 'Updated'}"
+        self.assertEqual(expected_error, str(context.exception))
+
+    empty_table_identifier_event = {
+        "Records": [
+            {
+                "messageId": "dfef2ac4-7b37-437e-bf65-56e687784975",
+                "receiptHandle": "AQEBzWwaftRI0KuVm4tP+/7q1rGgNqicHq...",
+                "body": "{\"tableItemIdentifier\": \"\", \"status\":\"Updated\"}"
+            }
+        ]
+    }
 
     default_event = {
         "Records": [


### PR DESCRIPTION
We're getting a syntax warning
`SyntaxWarning: "is not" with a literal. Did you mean "!="`

This is a decent description of the change that caused it. https://adamj.eu/tech/2020/01/21/why-does-python-3-8-syntaxwarning-for-is-literal/

This isn't affecting anything but it shows up in the logs a lot so it would be nice to stop that.